### PR TITLE
Allow “undefined” as a definition of any type

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Finally a member named "protocol" must be set in your implementation that define
 module.exports.protocol = protocol.implement(impl, 'myProtocol.js')
 ```
 
+## Typpes ##
+
+It is allowed to use any kind of type as a definition. Object(), Array(), function(), String()... 
+
+A special case is ```undefined``` that is there to allow anything. 
+
 ## protocol.implement ##
 
 Implement does have 3 Parameters:

--- a/protocols.js
+++ b/protocols.js
@@ -91,7 +91,7 @@ protocols.implement =  function(clazz, protocols, breakOnError){
         
         var p = _.map(_.keys(m), function(e){
             if( _.has(clazz, e)  ){
-                if( typeof clazz[e] === typeof m[e] ){
+                if(  m[e] === undefined || (typeof clazz[e] === typeof m[e]) ){
                     return S(path.basename(protocol)).chompRight(path.extname(protocol)).s;
                 }
             }

--- a/tests/mocks/nullProtocol.js
+++ b/tests/mocks/nullProtocol.js
@@ -1,0 +1,5 @@
+/*global Buffer: false, clearInterval: false, clearTimeout: false, console: false, exports: false, global: false, module: false, process: false, querystring: false, require: false, setInterval: false, setTimeout: false, __filename: false, __dirname: false */
+
+module.exports.foo = function(){};
+module.exports.bar = undefined;
+module.exports.s = String();

--- a/tests/mocks/undefined/implementation_1.js
+++ b/tests/mocks/undefined/implementation_1.js
@@ -1,0 +1,13 @@
+/*global Buffer: false, clearInterval: false, clearTimeout: false, console: false, exports: false, global: false, module: false, process: false, querystring: false, require: false, setInterval: false, setTimeout: false, __filename: false, __dirname: false */
+
+var protocol = require('../../../protocols');
+
+var impl = module.exports = {
+    foo: function(){
+        console.log("I am foo");
+    },
+     bar: "",
+    s: ""
+}
+
+module.exports.protocol = protocol.implement(impl, __dirname + '/../nullProtocol.js', false)

--- a/tests/mocks/undefined/implementation_2.js
+++ b/tests/mocks/undefined/implementation_2.js
@@ -1,0 +1,15 @@
+/*global Buffer: false, clearInterval: false, clearTimeout: false, console: false, exports: false, global: false, module: false, process: false, querystring: false, require: false, setInterval: false, setTimeout: false, __filename: false, __dirname: false */
+
+var protocol = require('../../../protocols');
+
+var impl = module.exports = {
+    foo: function(){
+        console.log("I am foo");
+    },
+     bar: {
+        a: 1
+    },
+    s: ""
+}
+
+module.exports.protocol = protocol.implement(impl, __dirname + '/../nullProtocol.js', false)

--- a/tests/nullProtocolTest.js
+++ b/tests/nullProtocolTest.js
@@ -1,0 +1,32 @@
+/*global Buffer: false, clearInterval: false, clearTimeout: false, console: false, exports: false, global: false, module: false, process: false, querystring: false, require: false, setInterval: false, describe: false, it: false, setTimeout: false, __filename: false, __dirname: false */
+
+var assert = require("assert")
+    , chai = require("chai")
+    ;
+
+describe('Undefined in Protocol', function () {
+    it('should fullfill on Objects.', function () {
+        var test = require('./mocks/undefined/implementation_1.js');
+        
+        chai.expect(test).to.have.property(
+            'confirmsToProtocols'
+        );
+         chai.expect(test).to.have.property(
+            'fulfillProtocols'
+        );
+        chai.expect(test.confirmsToProtocols).to.have.length(1);
+        chai.expect(test.fulfillProtocols).to.be.true;
+    });
+    it('should fullfill on String.', function () {
+        var test = require('./mocks/undefined/implementation_2.js');
+        
+        chai.expect(test).to.have.property(
+            'confirmsToProtocols'
+        );
+         chai.expect(test).to.have.property(
+            'fulfillProtocols'
+        );
+        chai.expect(test.confirmsToProtocols).to.have.length(1);
+        chai.expect(test.fulfillProtocols).to.be.true;
+    });    
+});


### PR DESCRIPTION
We should use "undefined" as a "any type" definition.